### PR TITLE
⚡ Bolt: [Prisma count optimization]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-31 - [Prisma Performance: Count vs Length]
+**Learning:** Using `findMany().length` to determine the count of records in Prisma is a significant performance bottleneck because it fetches all entire records from the database into memory just to return an integer length.
+**Action:** Always use Prisma's `count()` method when only the number of records is needed, avoiding large memory footprints and potential N+1 issues.

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -717,13 +717,14 @@ export const upsertLane = async (lane : Prisma.LaneUncheckedCreateInput) => {
     let order: number = 0;
 
     if (!lane.order) {
-        const lanes = await db.lane.findMany({
+        // Optimize: use count instead of fetching all records to memory
+        const lanesLength = await db.lane.count({
             where: {
                 pipelineId: lane.pipelineId
             }
         });
 
-        order = lanes.length;
+        order = lanesLength;
     }
     else {
         order = lane.order;
@@ -824,13 +825,14 @@ export const upsertTicket = async (ticket: Prisma.TicketUncheckedCreateInput, ta
     
     let order: number = 0;
     if (!ticket.order) {
-        const tickets = await db.ticket.findMany({
+        // Optimize: use count instead of fetching all records to memory
+        const ticketsLength = await db.ticket.count({
             where: {
                 laneId: ticket.laneId
             },
             
         })
-        order = tickets.length
+        order = ticketsLength
     }
     else {
         order = ticket.order


### PR DESCRIPTION
💡 What: Replaced Prisma's `findMany(...).length` with `count(...)` in `upsertLane` and `upsertTicket` within `web_app/src/lib/queries.ts`.
🎯 Why: The previous approach was fetching all records from the database into the application's memory just to calculate the total number of records (for finding the next `order` index), which is a significant performance bottleneck and memory hog.
📊 Impact: Considerably reduces memory footprint and database load when calculating order sizes, especially for pipelines and tickets that have many entries.
🔬 Measurement: Verify the change locally or monitor application memory and database load during ticket or lane creation in high-volume subaccounts.

---
*PR created automatically by Jules for task [16851998091348019301](https://jules.google.com/task/16851998091348019301) started by @lakshyarawat1*