### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in changeUserPermissions

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -6,3 +6,8 @@
 **Vulnerability:** The `deleteUser` Server Action in `web_app/src/lib/queries.ts` lacked both authentication and authorization checks. It directly deleted a user based on the provided `userId`.
 **Learning:** Next.js Server Actions function as publicly exposed API endpoints. Because this action took an ID as a parameter without verifying permissions, it allowed for Insecure Direct Object Reference (IDOR). Any caller could potentially exploit this to delete arbitrary users by ID.
 **Prevention:** Always verify `currentUser()` for authentication and cross-reference the user's role (e.g., `AGENCY_OWNER` or `AGENCY_ADMIN`) and agency ID against the target object's agency ID before performing sensitive operations in Server Actions.
+
+## 2024-06-06 - Missing IDOR Prevention in changeUserPermissions Action
+**Vulnerability:** The `changeUserPermissions` Server Action in `web_app/src/lib/queries.ts` lacked both authentication and authorization checks. It directly upserted permission records based on the provided parameters.
+**Learning:** Next.js Server Actions function as publicly exposed API endpoints. Without verifying permissions, it allowed for Insecure Direct Object Reference (IDOR) / Privilege Escalation. Any caller could potentially exploit this to give themselves or others unauthorized access to subaccounts.
+**Prevention:** Always verify `currentUser()` for authentication and cross-reference the user's agency ID against the target object's agency ID before performing sensitive operations in Server Actions.

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -522,6 +522,31 @@ export const updateUser = async (user: Partial<User>) => {
 }
 
 export const changeUserPermissions = async (permissionId: string | undefined, userEmail : string, subAccountId : string, permissions: boolean) => {
+    const authUser = await currentUser()
+    if (!authUser) {
+      throw new Error('Unauthorized')
+    }
+
+    const authUserData = await db.user.findUnique({
+      where: { email: authUser.emailAddresses[0].emailAddress },
+    })
+
+    if (!authUserData) {
+      throw new Error('Unauthorized')
+    }
+
+    if (authUserData.role !== 'AGENCY_OWNER' && authUserData.role !== 'AGENCY_ADMIN') {
+        throw new Error('Unauthorized to change permissions')
+    }
+
+    const subAccount = await db.subAccount.findUnique({
+        where: { id: subAccountId }
+    })
+
+    if (!subAccount || subAccount.agencyId !== authUserData.agencyId) {
+        throw new Error('Unauthorized to change permissions for this subaccount')
+    }
+
     try {
         const res = await db.permission.upsert({
             where: {


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `changeUserPermissions` Server Action lacked both authentication and authorization checks. It directly modified permission records based on user input.
🎯 **Impact**: Allowed for Insecure Direct Object Reference (IDOR) and Privilege Escalation. Any caller could potentially modify permissions for any subaccount, allowing unauthorized access.
🔧 **Fix**: Added verification of `currentUser()` and strict authorization checks to ensure the user belongs to the target subaccount's agency and has an administrative role (`AGENCY_OWNER` or `AGENCY_ADMIN`).
✅ **Verification**: Verified using `pnpm build` and `pnpm lint`. The action now strictly enforces authorization before updating the database. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [4321901743970089549](https://jules.google.com/task/4321901743970089549) started by @lakshyarawat1*