### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix IDOR in deleteTicket

### DIFF
--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -1180,6 +1180,49 @@ export const upsertTicket = async (ticket: Prisma.TicketUncheckedCreateInput, ta
 }
 
 export const deleteTicket = async (ticketId : string) => {
+    // 🛡️ SECURITY: Verify user is authenticated
+    const authUser = await currentUser()
+    if (!authUser) {
+        throw new Error('Unauthorized')
+    }
+
+    const authUserData = await db.user.findUnique({
+        where: { email: authUser.emailAddresses[0].emailAddress },
+    })
+
+    if (!authUserData) {
+        throw new Error('Unauthorized')
+    }
+
+    // 🛡️ SECURITY: Fetch target ticket and verify authorization
+    const ticket = await db.ticket.findUnique({
+        where: { id: ticketId },
+        include: { Lane: { include: { Pipeline: { include: { SubAccount: true } } } } }
+    })
+
+    if (!ticket || !ticket.Lane || !ticket.Lane.Pipeline || !ticket.Lane.Pipeline.SubAccount) {
+        throw new Error('Ticket not found')
+    }
+
+    // Check if the user belongs to the same agency
+    if (ticket.Lane.Pipeline.SubAccount.agencyId !== authUserData.agencyId) {
+        throw new Error('Unauthorized to delete this ticket')
+    }
+
+    // If they are a subaccount user, check permissions
+    if (authUserData.role === 'SUBACCOUNT_USER' || authUserData.role === 'SUBACCOUNT_GUEST') {
+        const hasPermission = await db.permission.findFirst({
+            where: {
+                email: authUserData.email,
+                subAccountId: ticket.Lane.Pipeline.subAccountId,
+                access: true
+            }
+        })
+        if (!hasPermission) {
+            throw new Error('Unauthorized to delete this ticket')
+        }
+    }
+
     const res = await db.ticket.delete({
         where: {
             id : ticketId


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Insecure Direct Object Reference (IDOR) in `deleteTicket` server action. Any authenticated user (or unauthenticated, depending on endpoint exposure) could provide an arbitrary `ticketId` and delete tickets belonging to other agencies or subaccounts.
🎯 Impact: Attackers could delete critical data (tickets) across the entire application, leading to severe data loss and disruption of service for all users.
🔧 Fix: Implemented multi-layered authorization checks. First, it verifies the user is authenticated. Then, it fetches the target ticket and validates that the user's `agencyId` matches the ticket's `agencyId` (via the subaccount). For subaccount users, it additionally verifies explicit database permissions for the specific subaccount.
✅ Verification: Ensure the server action throws an 'Unauthorized' or 'Unauthorized to delete this ticket' error when called by a user who does not have explicit access to the ticket's subaccount or agency. Run `pnpm build` to ensure no regressions are introduced.

---
*PR created automatically by Jules for task [7018969160859454406](https://jules.google.com/task/7018969160859454406) started by @lakshyarawat1*