### PR TITLE
⚡ Bolt: Optimize funnel page duplication count query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,3 @@
-## 2024-05-31 - [Prisma Performance: Count vs Length]
-**Learning:** Using `findMany().length` to determine the count of records in Prisma is a significant performance bottleneck because it fetches all entire records from the database into memory just to return an integer length.
-**Action:** Always use Prisma's `count()` method when only the number of records is needed, avoiding large memory footprints and potential N+1 issues.
+## 2024-05-14 - Prisma Count vs findMany Length
+**Learning:** Found another instance where `findMany({ include: { relations: true } }).length` was used just to get a count (in `CreateFunnelPage.tsx` for duplicating funnel pages). This causes Prisma to fetch the full relational graph into application memory, creating a significant bottleneck.
+**Action:** Always replace `.length` checks on `findMany` results with a dedicated `db.model.count()` query when the full dataset is not actually needed.

--- a/web_app/src/components/forms/CreateFunnelPage.tsx
+++ b/web_app/src/components/forms/CreateFunnelPage.tsx
@@ -28,6 +28,7 @@ import { FunnelPageSchema } from "@/lib/types";
 import {
   deleteFunnelPage,
   getFunnels,
+  getFunnelPageCount,
   saveActivityLogsNotification,
   upsertFunnelPage,
 } from "@/lib/queries";
@@ -186,10 +187,8 @@ const CreateFunnelPage: React.FC<CreateFunnelPageProps> = ({
                   disabled={form.formState.isSubmitting}
                   type="button"
                   onClick={async () => {
-                    const response = await getFunnels(subAccountId);
-                    const lastFunnelPage = response.find(
-                      (funnel) => funnel.id === funnelId
-                    )?.FunnelPages.length;
+                    // ⚡ Bolt Optimization: Use a dedicated count query instead of fetching all funnels and pages
+                    const lastFunnelPage = await getFunnelPageCount(funnelId);
 
                     await upsertFunnelPage(
                       subAccountId,

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -421,6 +421,15 @@ export const upsertSubAccount = async (subAccount: SubAccount) => {
     return res;
 }
 
+export const getFunnelPageCount = async (funnelId: string) => {
+    const res = await db.funnelPage.count({
+        where: {
+            funnelId
+        }
+    })
+    return res;
+}
+
 export const getUserPermissions = async (userId: string) => {
     const res = await db.user.findUnique({
         where: {


### PR DESCRIPTION
💡 **What:** Replaced a heavy `db.funnel.findMany({ include: { FunnelPages: true } }).length` query with a direct `db.funnelPage.count({ where: { funnelId } })` query inside the duplication handler of `CreateFunnelPage.tsx`.

🎯 **Why:** To duplicate a page, the component previously fetched the entire graph of funnels and their pages for the subaccount just to find the length of the pages for one funnel. This causes Prisma to fetch unnecessary rows into memory.

📊 **Impact:** Reduces database transfer size and JS heap memory usage when duplicating funnel pages. The query is now $O(1)$ instead of $O(N)$ (where N is the number of funnels + funnel pages for the subaccount).

🔬 **Measurement:** Verify by duplicating a funnel page and observing the Prisma query logs or application memory usage.

---
*PR created automatically by Jules for task [3545978592540304276](https://jules.google.com/task/3545978592540304276) started by @lakshyarawat1*