### PR TITLE
⚡ Bolt: Limit searchContacts autocomplete query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-14 - Prisma Count vs findMany Length
 **Learning:** Found another instance where `findMany({ include: { relations: true } }).length` was used just to get a count (in `CreateFunnelPage.tsx` for duplicating funnel pages). This causes Prisma to fetch the full relational graph into application memory, creating a significant bottleneck.
 **Action:** Always replace `.length` checks on `findMany` results with a dedicated `db.model.count()` query when the full dataset is not actually needed.
+## 2024-05-15 - Unbounded FindMany Searches
+**Learning:** Broad search queries (like autocomplete using `contains`) can result in massive payloads if no limit is set on the returned records.
+**Action:** Always add `take: <limit>` to Prisma queries that fetch data for UI autocomplete dropdowns.

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -824,7 +824,8 @@ export const searchContacts = async (searchTerms : string) => {
             name: {
                 contains : searchTerms
             }
-        }
+        },
+        take: 10 // ⚡ Bolt Optimization: Limit autocomplete search results to prevent massive payloads on broad queries
     })
 
     return res;


### PR DESCRIPTION
💡 What: Added `take: 10` to `searchContacts` query.
🎯 Why: Prevents massive database payloads and slow queries when users enter broad search terms into autocomplete fields.
📊 Impact: Limits the response to 10 records, reducing memory usage and network transfer for broad searches.
🔬 Measurement: Verify autocomplete in TicketForm still returns correct contact results, but no longer requests an unbounded number of rows.

---
*PR created automatically by Jules for task [13885531322351343036](https://jules.google.com/task/13885531322351343036) started by @lakshyarawat1*