### PR TITLE
⚡ Bolt: Optimize FunnelPages payload in Subaccount page

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,7 @@
 ## 2024-05-15 - Unbounded FindMany Searches
 **Learning:** Broad search queries (like autocomplete using `contains`) can result in massive payloads if no limit is set on the returned records.
 **Action:** Always add `take: <limit>` to Prisma queries that fetch data for UI autocomplete dropdowns.
+
+## 2024-05-16 - Prisma Include Fetching Unused Heavy Columns
+**Learning:** Using `include: { Relation: true }` in Prisma queries blindly fetches all columns of the relation. In tables with heavy text or JSON columns (like `FunnelPages` which has a `content` column storing full page JSON), this results in massively oversized payloads being loaded into application memory just to calculate a simple sum or display small fields like `name` and `visits`.
+**Action:** Always use a nested `select` within `include` blocks to only fetch the explicitly required fields from the relation when dealing with tables that have heavy columns.

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/page.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/page.tsx
@@ -59,12 +59,19 @@ const SubaccountPageId = async ({ params, searchParams }: Props) => {
 
   if (!subaccountDetails) return;
 
+  // ⚡ Bolt Optimization: Use a nested select to only fetch the required fields for FunnelPages, avoiding loading heavy content text into memory
   const funnels = await db.funnel.findMany({
     where: {
       subAccountId: params.subAccountId,
     },
     include: {
-      FunnelPages: true,
+      FunnelPages: {
+        select: {
+          id: true,
+          name: true,
+          visits: true,
+        },
+      },
     },
   });
 


### PR DESCRIPTION
💡 What: Replaced `include: { FunnelPages: true }` with a nested `select` targeting only `id`, `name`, and `visits` inside the `db.funnel.findMany` query.

🎯 Why: The original query fetched all fields for every `FunnelPage` related to the subaccount's funnels. Because `FunnelPages` contains a very heavy `content` field (storing full page JSON), this resulted in a massively oversized payload being loaded into application memory just to calculate visits and display small fields in a tooltip.

📊 Impact: Significantly reduces database network transfer time and application memory usage by avoiding the retrieval of heavy unused columns. Reduces payload size dramatically, making the dashboard load faster.

🔬 Measurement: Verify by checking the size of the payload returned by the database for the `funnels` query on the Subaccount Dashboard route (`/subaccount/[subAccountId]`), or by observing reduced memory spikes when loading subaccounts with complex funnels.

---
*PR created automatically by Jules for task [2523905047288798471](https://jules.google.com/task/2523905047288798471) started by @lakshyarawat1*