### PR TITLE
⚡ Bolt: Prevent unbounded payload growth in notifications query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -8,3 +8,7 @@
 ## 2024-05-16 - Prisma Include Fetching Unused Heavy Columns
 **Learning:** Using `include: { Relation: true }` in Prisma queries blindly fetches all columns of the relation. In tables with heavy text or JSON columns (like `FunnelPages` which has a `content` column storing full page JSON), this results in massively oversized payloads being loaded into application memory just to calculate a simple sum or display small fields like `name` and `visits`.
 **Action:** Always use a nested `select` within `include` blocks to only fetch the explicitly required fields from the relation when dealing with tables that have heavy columns.
+
+## 2024-06-20 - Unbounded History Feeds
+**Learning:** Fetching historical logs or feeds (like notifications) using `findMany` without bounds will cause performance to degrade over time as the database accumulates records, leading to unbounded payload growth and database execution delays.
+**Action:** Always apply a reasonable limit (e.g., `take: 50`) when querying chronological feeds or history logs using Prisma `findMany`.

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -315,6 +315,7 @@ export const getNotificationAndUser = async (agencyId: string) => {
             orderBy: {
                 createdAt: 'desc'
             },
+            take: 50 // ⚡ Bolt Optimization: Limit notifications to prevent unbounded payload growth as history accumulates
         })
         return res;
     } catch (err) {


### PR DESCRIPTION
💡 What: Added a `take: 50` limit to the `db.notification.findMany` query in `getNotificationAndUser`.
🎯 Why: Without a limit, this query fetches the entire history of notifications for an agency. Over time, as the database accumulates records, this unbounded query creates a significant performance bottleneck by loading increasingly massive payloads into application memory and slowing down database response times.
📊 Impact: Prevents memory overflow and stabilizes database query execution time, ensuring consistent performance for the agency dashboard regardless of how long the agency has been active.
🔬 Measurement: Verify by checking the application memory and Prisma execution times for the `getNotificationAndUser` function when logging into an agency with a large amount of historical notifications.

---
*PR created automatically by Jules for task [4798374193614902191](https://jules.google.com/task/4798374193614902191) started by @lakshyarawat1*