### PR TITLE
⚡ Bolt: [performance improvement] Prevent unnecessary re-renders in PipelineValue by removing state side-effect in useMemo

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-18 - [Limit Notification History Fetches]
 **Learning:** Found a query (`getNotificationAndUser`) pulling full chronological histories without any limit, causing an N+1 payload/memory issue that grows over time.
 **Action:** Always apply limits (`take: 50`) to time-series data or logs to avoid unbounded payload size.
+## 2023-11-06 - [React Performance Pattern: Derived state instead of side-effect in useMemo]
+**Learning:** Found an anti-pattern in `PipelineValue.tsx` where a `useState` setter (`setPipelineClosedValue`) was called inside a `useMemo` block. This triggers side effects during the render phase, causing unnecessary extra renders.
+**Action:** When computing multiple values that depend on the same logic (like summing up a total and grabbing the final value), return an object with all derived values directly from the `useMemo` instead of calculating one and modifying state for the other. This ensures pure rendering and improves performance by preventing multiple render cycles.

--- a/web_app/src/components/global/PipelineValue.tsx
+++ b/web_app/src/components/global/PipelineValue.tsx
@@ -24,7 +24,6 @@ const PipelineValue = ({ subaccountId }: Props) => {
   >([]);
 
   const [selectedPipelineId, setselectedPipelineId] = useState("");
-  const [pipelineClosedValue, setPipelineClosedValue] = useState(0);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -35,25 +34,31 @@ const PipelineValue = ({ subaccountId }: Props) => {
     fetchData();
   }, [subaccountId]);
 
-  const totalPipelineValue = useMemo(() => {
+  // ⚡ Bolt Optimization: Calculate both total and closed values in a single pass without setting state inside useMemo
+  // This prevents unnecessary re-renders that occur when a state setter is called during the render phase
+  const { totalPipelineValue, pipelineClosedValue } = useMemo(() => {
     if (pipelines.length) {
       return (
         pipelines
           .find((pipeline) => pipeline.id === selectedPipelineId)
-          ?.Lane?.reduce((totalLanes, lane, currentLaneIndex, array) => {
-            const laneTicketsTotal = lane.Tickets.reduce(
-              (totalTickets, ticket) => totalTickets + Number(ticket?.value),
-              0
-            );
-            if (currentLaneIndex === array.length - 1) {
-              setPipelineClosedValue(laneTicketsTotal || 0);
-              return totalLanes;
-            }
-            return totalLanes + laneTicketsTotal;
-          }, 0) || 0
+          ?.Lane?.reduce(
+            (acc, lane, currentLaneIndex, array) => {
+              const laneTicketsTotal = lane.Tickets.reduce(
+                (totalTickets, ticket) => totalTickets + Number(ticket?.value),
+                0
+              );
+              if (currentLaneIndex === array.length - 1) {
+                acc.pipelineClosedValue = laneTicketsTotal || 0;
+              } else {
+                acc.totalPipelineValue += laneTicketsTotal;
+              }
+              return acc;
+            },
+            { totalPipelineValue: 0, pipelineClosedValue: 0 }
+          ) || { totalPipelineValue: 0, pipelineClosedValue: 0 }
       );
     }
-    return 0;
+    return { totalPipelineValue: 0, pipelineClosedValue: 0 };
   }, [selectedPipelineId, pipelines]);
 
   const pipelineRate = useMemo(


### PR DESCRIPTION
💡 What: Refactored `PipelineValue.tsx` to calculate `pipelineClosedValue` and `totalPipelineValue` simultaneously inside the `useMemo` block and return both as an object, rather than calling the state setter `setPipelineClosedValue` inside the memo hook.
🎯 Why: Calling a state setter inside a `useMemo` is a React anti-pattern that creates a side effect during the render phase, causing React to immediately trigger another render cycle. This change makes the component's rendering pure and eliminates unnecessary re-renders.
📊 Impact: Eliminates an entire redundant render cycle every time the `pipelines` dependency updates, improving rendering efficiency.
🔬 Measurement: Verify by checking that the "Pipeline Progress" chart still displays accurate numbers and the application functions smoothly without extra renders upon changing pipelines.

---
*PR created automatically by Jules for task [12355106083731149188](https://jules.google.com/task/12355106083731149188) started by @lakshyarawat1*