### PR TITLE
⚡ Bolt: Remove React state setter from useMemo in PipelineValue

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-06-18 - [Limit Notification History Fetches]
 **Learning:** Found a query (`getNotificationAndUser`) pulling full chronological histories without any limit, causing an N+1 payload/memory issue that grows over time.
 **Action:** Always apply limits (`take: 50`) to time-series data or logs to avoid unbounded payload size.
+## 2026-06-22 - [React Render Anti-pattern]
+**Learning:** Calling a state setter inside a `useMemo` block causes side effects during the render phase, leading to immediate unnecessary re-renders in Next.js/React applications.
+**Action:** Always compute derived values directly within `useMemo` and return them (e.g. as an object) instead of triggering a state update from within the hook.

--- a/web_app/src/components/global/PipelineValue.tsx
+++ b/web_app/src/components/global/PipelineValue.tsx
@@ -24,7 +24,6 @@ const PipelineValue = ({ subaccountId }: Props) => {
   >([]);
 
   const [selectedPipelineId, setselectedPipelineId] = useState("");
-  const [pipelineClosedValue, setPipelineClosedValue] = useState(0);
 
   useEffect(() => {
     const fetchData = async () => {
@@ -35,30 +34,42 @@ const PipelineValue = ({ subaccountId }: Props) => {
     fetchData();
   }, [subaccountId]);
 
-  const totalPipelineValue = useMemo(() => {
+  // ⚡ Bolt Optimization: Compute total and closed pipeline values in a single pass within useMemo.
+  // This removes a React performance anti-pattern where a state setter was called during render,
+  // preventing immediate unnecessary re-renders.
+  const pipelineInfo = useMemo(() => {
     if (pipelines.length) {
-      return (
-        pipelines
-          .find((pipeline) => pipeline.id === selectedPipelineId)
-          ?.Lane?.reduce((totalLanes, lane, currentLaneIndex, array) => {
-            const laneTicketsTotal = lane.Tickets.reduce(
-              (totalTickets, ticket) => totalTickets + Number(ticket?.value),
-              0
-            );
-            if (currentLaneIndex === array.length - 1) {
-              setPipelineClosedValue(laneTicketsTotal || 0);
-              return totalLanes;
-            }
-            return totalLanes + laneTicketsTotal;
-          }, 0) || 0
-      );
+      const pipeline = pipelines.find((pipeline) => pipeline.id === selectedPipelineId);
+      if (pipeline && pipeline.Lane) {
+        let totalValue = 0;
+        let closedValue = 0;
+
+        pipeline.Lane.forEach((lane, currentLaneIndex, array) => {
+          const laneTicketsTotal = lane.Tickets.reduce(
+            (totalTickets, ticket) => totalTickets + Number(ticket?.value),
+            0
+          );
+
+          if (currentLaneIndex === array.length - 1) {
+            closedValue = laneTicketsTotal || 0;
+          } else {
+            totalValue += laneTicketsTotal;
+          }
+        });
+
+        return { totalPipelineValue: totalValue, pipelineClosedValue: closedValue };
+      }
     }
-    return 0;
+    return { totalPipelineValue: 0, pipelineClosedValue: 0 };
   }, [selectedPipelineId, pipelines]);
 
+  const { totalPipelineValue, pipelineClosedValue } = pipelineInfo;
+
   const pipelineRate = useMemo(
-    () =>
-      (pipelineClosedValue / (totalPipelineValue + pipelineClosedValue)) * 100,
+    () => {
+      if (totalPipelineValue + pipelineClosedValue === 0) return 0;
+      return (pipelineClosedValue / (totalPipelineValue + pipelineClosedValue)) * 100;
+    },
     [pipelineClosedValue, totalPipelineValue]
   );
 


### PR DESCRIPTION
💡 What: Refactored `totalPipelineValue` computation to compute both `totalPipelineValue` and `pipelineClosedValue` simultaneously in a single `useMemo` pass, replacing the `setPipelineClosedValue` state hook.
🎯 Why: Calling a React state setter inside a `useMemo` hook is a performance anti-pattern because it introduces a side effect during the render phase, causing React to schedule an immediate unnecessary re-render.
📊 Impact: Eliminates an unnecessary re-render cycle whenever pipeline properties change or on initialization.
🔬 Measurement: Verify by reviewing `web_app/src/components/global/PipelineValue.tsx` and ensuring Next.js builds properly and tests pass without immediate render cycle side effects. Added a fallback zero-division check to `pipelineRate` to improve robustness.

---
*PR created automatically by Jules for task [13796945120685651928](https://jules.google.com/task/13796945120685651928) started by @lakshyarawat1*