### PR TITLE
⚡ Bolt: Refactor O(N*M) nested render loops into O(1) hash map lookups in Sidebar components

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-06-22 - [React Render Anti-pattern]
 **Learning:** Calling a state setter inside a `useMemo` block causes side effects during the render phase, leading to immediate unnecessary re-renders in Next.js/React applications.
 **Action:** Always compute derived values directly within `useMemo` and return them (e.g. as an object) instead of triggering a state update from within the hook.
+## 2024-05-24 - [O(N*M) Rendering Anti-Patterns in Sidebar]
+**Learning:** Found an instance in `web_app/src/components/sidebar/MenuOptions.tsx` where an array `.find()` was nested inside a `.map()` during render, and another in `web_app/src/components/sidebar/index.tsx` where `.find()` was nested inside `.filter()`. These create O(N*M) time complexity during critical render paths. The `MenuOptions` loop actually contained a bug where the callback was missing a `return` statement, causing silent lookup failures, which the refactor inherently fixed.
+**Action:** When working with nested collections in render loops (like sidebar options or nested arrays), prioritize extracting the inner lookup into an O(1) Map or Set outside the component (or memoized) to avoid compounding render times.

--- a/web_app/src/components/sidebar/MenuOptions.tsx
+++ b/web_app/src/components/sidebar/MenuOptions.tsx
@@ -39,6 +39,9 @@ type Props = {
   id: string;
 };
 
+// ⚡ Bolt Optimization: Pre-compute icon map outside component for O(1) rendering lookups
+const iconMap = new Map(icons.map(icon => [icon.value, icon.path]));
+
 const MenuOptions = ({
   defaultOpen,
   subAccounts,
@@ -261,14 +264,10 @@ const MenuOptions = ({
                 <CommandEmpty>No Results Found</CommandEmpty>
                 <CommandGroup className="overflow-visible">
                   {sideBarOptions.map((sidebaroption) => {
-                    let val;
-                    const results = icons.find((icon) => {
-                      icon.value === sidebaroption.icon
-                    })
+                    // ⚡ Bolt Optimization: Replace O(N*M) nested `.find()` with O(1) map lookup
+                    const IconComponent = iconMap.get(sidebaroption.icon);
+                    const val = IconComponent ? <IconComponent /> : null;
 
-                    if (results) {
-                      val = <results.path />
-                    }
                     return (
                       <CommandItem key={sidebaroption.id} className="md:w-[320px] w-full">
                         <Link href={sidebaroption.link} className="hover:bg-transparent rounded-md flex items-center gap-2 transition-all md:w-full w-[320px]">

--- a/web_app/src/components/sidebar/index.tsx
+++ b/web_app/src/components/sidebar/index.tsx
@@ -16,10 +16,12 @@ const Sidebar = async ({ id, type }: Props) => {
 
   if (!user.agency) return;
 
-  const details =
-    type === "agency"
-      ? user?.agency
-      : user?.agency.subAccount.find((subaccount) => subaccount.id === id);
+  // ⚡ Bolt Optimization: Cache the active subAccount to avoid O(N) array search 3 separate times
+  const currentSubAccount = type === "subaccount"
+    ? user.agency.subAccount.find((subaccount) => subaccount.id === id)
+    : null;
+
+  const details = type === "agency" ? user?.agency : currentSubAccount;
 
   const isWhiteLabelledAgency = user.agency.whiteLabel;
   if (!details) return;
@@ -27,24 +29,23 @@ const Sidebar = async ({ id, type }: Props) => {
   let SidebarLogo = user.agency.agencyLogo || "/assets/plura-logo.svg";
 
   if (!isWhiteLabelledAgency) {
-    if (type === "subaccount") {
-      SidebarLogo =
-        user?.agency.subAccount.find((subaccount) => subaccount.id === id)
-          ?.subAccountLogo || user.agency.agencyLogo;
+    if (type === "subaccount" && currentSubAccount) {
+      SidebarLogo = currentSubAccount.subAccountLogo || user.agency.agencyLogo;
     }
   }
 
   const sidebarOptions =
     type === "agency"
       ? user.agency.SideBarOption || []
-      : user.agency.subAccount.find((subaccount) => subaccount.id === id)
-          ?.SidebarOption || [];
+      : currentSubAccount?.SidebarOption || [];
 
-  const subAccount = user.agency.subAccount.filter((subAccount) =>
-    user.Permissions.find(
-      (permission) =>
-        permission.subAccountId === subAccount.id && permission.access
-    )
+  // ⚡ Bolt Optimization: Replace O(N*M) nested loop (filter + find) with O(N+M) Set lookup
+  const permissionMap = new Set(
+    user.Permissions.filter((p) => p.access).map((p) => p.subAccountId)
+  );
+
+  const subAccount = user.agency.subAccount.filter((subAcc) =>
+    permissionMap.has(subAcc.id)
   );
 
   return (


### PR DESCRIPTION
💡 What: Refactored the `Sidebar` and `MenuOptions` components to use O(1) dictionary and Set lookups instead of redundant, nested O(N*M) array operations (`.find()` inside `.map()` or `.filter()`).
🎯 Why: Nested array lookups inside component render loops create a performance bottleneck, triggering expensive computations on every re-render.
📊 Impact: Reduces rendering time complexity from O(N*M) to O(N+M) for sidebar calculations. Caches `currentSubAccount` so an O(N) lookup isn't executed 3 separate times on each render. Also implicitly fixes a silent bug in `MenuOptions` where an inner `.find()` was missing a `return` statement.
🔬 Measurement: Verify that `pnpm run lint` and `pnpm run build` still succeed without errors and check the application renders the Sidebar and Menu Options visually identical to the unpatched version, but measurably faster during profile timings.

---
*PR created automatically by Jules for task [8388871850138823786](https://jules.google.com/task/8388871850138823786) started by @lakshyarawat1*