### PR TITLE
⚡ Bolt: Optimize `getFunnels` to avoid fetching heavy `content` payloads

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -4,3 +4,6 @@
 ## 2026-06-22 - [React Render Anti-pattern]
 **Learning:** Calling a state setter inside a `useMemo` block causes side effects during the render phase, leading to immediate unnecessary re-renders in Next.js/React applications.
 **Action:** Always compute derived values directly within `useMemo` and return them (e.g. as an object) instead of triggering a state update from within the hook.
+## 2024-07-23 - [Optimization: Avoid fetching heavy text content on getFunnels]
+**Learning:** Found a performance bottleneck where querying funnels using Prisma's `include: { FunnelPages: true }` loaded heavy JSON/text `content` column data for all pages into memory unnecessarily, leading to huge payload size and massive latency hits.
+**Action:** Used nested `select` inside `include` (e.g. `include: { FunnelPages: { select: { id: true, name: true, ... } } }`) to pick only necessary fields instead of implicitly fetching everything when `content` isn't needed. Next time, always check if all fields in a large relationship are needed, specifically large string fields.

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -976,7 +976,20 @@ export const getFunnels = async (subAccountId: string) => {
             subAccountId: subAccountId
         },
         include: {
-            FunnelPages : true,
+            // ⚡ Bolt Optimization: Use a nested select to only fetch the required fields for FunnelPages, avoiding loading heavy content text into memory
+            FunnelPages: {
+                select: {
+                    id: true,
+                    name: true,
+                    pathName: true,
+                    createdAt: true,
+                    updatedAt: true,
+                    visits: true,
+                    order: true,
+                    previewImage: true,
+                    funnelId: true,
+                }
+            }
         }
     })
 


### PR DESCRIPTION
💡 What: Replaced `include: { FunnelPages: true }` with a nested `select` object in `getFunnels` to explicitly select needed scalar fields (`id`, `name`, `pathName`, `createdAt`, `updatedAt`, `visits`, `order`, `previewImage`, `funnelId`) while omitting the heavy `content` field.
🎯 Why: In web builder architectures, `FunnelPages` contains a large `content` property for storing serialized HTML/JSON components. Loading this field when only rendering table metadata leads to excessive memory usage and degraded database performance.
📊 Impact: Considerably reduces database bandwidth, memory consumption, and data transfer sizes, improving dashboard loading times.
🔬 Measurement: Verify memory utilization drops when running queries calling `getFunnels`, or simply run `pnpm build` to confirm zero typing errors.

---
*PR created automatically by Jules for task [15211005720119936320](https://jules.google.com/task/15211005720119936320) started by @lakshyarawat1*