### PR TITLE
⚡ Bolt: Remove heavy FunnelPages payload from Funnels list query

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,7 @@
 ## 2024-05-24 - [O(N*M) Rendering Anti-Patterns in Sidebar]
 **Learning:** Found an instance in `web_app/src/components/sidebar/MenuOptions.tsx` where an array `.find()` was nested inside a `.map()` during render, and another in `web_app/src/components/sidebar/index.tsx` where `.find()` was nested inside `.filter()`. These create O(N*M) time complexity during critical render paths. The `MenuOptions` loop actually contained a bug where the callback was missing a `return` statement, causing silent lookup failures, which the refactor inherently fixed.
 **Action:** When working with nested collections in render loops (like sidebar options or nested arrays), prioritize extracting the inner lookup into an O(1) Map or Set outside the component (or memoized) to avoid compounding render times.
+
+## 2024-07-08 - [Avoid fetching FunnelPages with Funnels unnecessarily]
+**Learning:** The `FunnelPage` model contains a `content` field which stores the entire JSON tree for the page builder. Fetching `FunnelPages` alongside `Funnels` using Prisma's `include` in list views (like the funnels dashboard) causes massive payload sizes and severe memory bloat because it eagerly loads the heavy JSON blobs for every page of every funnel.
+**Action:** Always omit `FunnelPages` from `db.funnel.findMany` queries unless specifically required (e.g., when viewing a specific funnel's details). If page counts are needed, use Prisma's `_count` instead of fetching the full relation.

--- a/web_app/src/components/forms/CreateFunnelPage.tsx
+++ b/web_app/src/components/forms/CreateFunnelPage.tsx
@@ -27,7 +27,6 @@ import { FunnelPage } from "@prisma/client";
 import { FunnelPageSchema } from "@/lib/types";
 import {
   deleteFunnelPage,
-  getFunnels,
   getFunnelPageCount,
   saveActivityLogsNotification,
   upsertFunnelPage,

--- a/web_app/src/lib/queries.ts
+++ b/web_app/src/lib/queries.ts
@@ -975,9 +975,10 @@ export const getFunnels = async (subAccountId: string) => {
         where: {
             subAccountId: subAccountId
         },
-        include: {
-            FunnelPages : true,
-        }
+        // ⚡ Bolt Optimization: Removed `include: { FunnelPages: true }` because the funnel
+        // dashboard table does not use the funnel pages data. Fetching all pages along
+        // with their heavy `content` field (which stores the entire JSON page builder data)
+        // caused massive memory consumption and slow query times as the funnel grows.
     })
 
     return funnels;


### PR DESCRIPTION
💡 What: Removed `include: { FunnelPages: true }` from the `getFunnels` query in `lib/queries.ts`.
🎯 Why: The dashboard table for funnels does not use the funnel pages data. Fetching all `FunnelPages` (which includes the heavy `content` field storing the entire JSON tree for the page builder) along with `Funnels` causes massive memory consumption and slow database response times as the funnels grow. This is an N+1-style data over-fetch.
📊 Impact: Significantly reduces query payload size and memory bloat on the server and client. The query now only fetches funnel metadata.
🔬 Measurement: Verify the funnels dashboard still loads correctly. Monitor query execution times and memory usage for the `/subaccount/[id]/funnels` route, which should see a drastic reduction.

Also includes cleanup of an unused import (`getFunnels`) in `CreateFunnelPage.tsx`.

---
*PR created automatically by Jules for task [1048076069872031423](https://jules.google.com/task/1048076069872031423) started by @lakshyarawat1*