### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat to avoid expensive instantiations in list render

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -7,3 +7,6 @@
 ## 2024-05-24 - [O(N*M) Rendering Anti-Patterns in Sidebar]
 **Learning:** Found an instance in `web_app/src/components/sidebar/MenuOptions.tsx` where an array `.find()` was nested inside a `.map()` during render, and another in `web_app/src/components/sidebar/index.tsx` where `.find()` was nested inside `.filter()`. These create O(N*M) time complexity during critical render paths. The `MenuOptions` loop actually contained a bug where the callback was missing a `return` statement, causing silent lookup failures, which the refactor inherently fixed.
 **Action:** When working with nested collections in render loops (like sidebar options or nested arrays), prioritize extracting the inner lookup into an O(1) Map or Set outside the component (or memoized) to avoid compounding render times.
+## 2026-07-10 - [Cache Intl.NumberFormat Instantiation]
+**Learning:** Instantiating `Intl` objects (like `Intl.NumberFormat`) is computationally expensive in JS engines (like V8). Placing them inside list render mapping functions forces re-instantiation per item, leading to unnecessary CPU overhead during rendering.
+**Action:** Always instantiate `Intl` formatter objects outside the component or loop scope so the single instance can be reused across all format calls.

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
@@ -14,6 +14,13 @@ type Props = {
   };
 };
 
+// ⚡ Bolt Optimization: Instantiate Intl.NumberFormat outside the render loop.
+// Instantiating Intl objects is computationally expensive, especially inside a map loop where it's called twice per contact.
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
 const page = async ({ params }: Props) => {
   type SubAccountWithContacts = SubAccount & {
     Contact: (Contact & { Ticket: Ticket[] })[];
@@ -43,17 +50,13 @@ const page = async ({ params }: Props) => {
 
   const formatTotal = (tickets: Ticket[]) => {
     if (!tickets || !tickets.length) return "$0.00";
-    const amount = new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: "USD",
-    });
 
     const laneAmt = tickets.reduce(
       (sum, ticket) => sum + (Number(ticket?.value) || 0),
       0
     );
 
-    return amount.format(laneAmt);
+    return currencyFormatter.format(laneAmt);
   };
 
   return (


### PR DESCRIPTION
💡 What: Moved the instantiation of `Intl.NumberFormat` outside the render loop in `subaccount/[subAccountId]/contacts/page.tsx` so the single instance is reused.
🎯 Why: Instantiating `Intl` objects is computationally expensive in JS engines. Doing so inside a list mapping function forces a new, expensive instantiation for every contact row.
📊 Impact: Reduces CPU overhead and slightly speeds up Server Component render times when there are many contacts.
🔬 Measurement: Verify that contact lists display currency correctly. Check build times and profile render times if needed.

---
*PR created automatically by Jules for task [17507947347489640150](https://jules.google.com/task/17507947347489640150) started by @lakshyarawat1*