### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat to prevent expensive re-instantiations

### DIFF
--- a/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
@@ -14,6 +14,12 @@ type Props = {
   };
 };
 
+// ⚡ Bolt: Cache Intl.NumberFormat outside component to prevent expensive re-instantiation on each render/loop iteration
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
 const page = async ({ params }: Props) => {
   type SubAccountWithContacts = SubAccount & {
     Contact: (Contact & { Ticket: Ticket[] })[];
@@ -43,17 +49,13 @@ const page = async ({ params }: Props) => {
 
   const formatTotal = (tickets: Ticket[]) => {
     if (!tickets || !tickets.length) return "$0.00";
-    const amount = new Intl.NumberFormat(undefined, {
-      style: "currency",
-      currency: "USD",
-    });
 
     const laneAmt = tickets.reduce(
       (sum, ticket) => sum + (Number(ticket?.value) || 0),
       0
     );
 
-    return amount.format(laneAmt);
+    return currencyFormatter.format(laneAmt);
   };
 
   return (
@@ -71,30 +73,33 @@ const page = async ({ params }: Props) => {
           </TableRow>
         </TableHeader>
         <TableBody>
-          {allContacts.map((contact) => (
-            <TableRow key={contact.id}>
-              <TableCell>
-                <Avatar>
-                  <AvatarImage alt="@shadcn" />
-                  <AvatarFallback className="bg-primary text-white">
-                    {contact.name.slice(0, 2).toUpperCase()}
-                  </AvatarFallback>
-                </Avatar>
-              </TableCell>
-              <TableCell>{contact.email}</TableCell>
-              <TableCell>
-                {formatTotal(contact.Ticket) === "$0.00" ? (
-                  <Badge variant={"destructive"}>Inactive</Badge>
-                ) : (
-                  <Badge className="bg-emerald-700">Active</Badge>
-                )}
-              </TableCell>
-              <TableCell>{format(contact.createdAt, "MM/dd/yyyy")}</TableCell>
-              <TableCell className="text-right">
-                {formatTotal(contact.Ticket)}
-              </TableCell>
-            </TableRow>
-          ))}
+          {allContacts.map((contact) => {
+            const formattedTotal = formatTotal(contact.Ticket);
+            return (
+              <TableRow key={contact.id}>
+                <TableCell>
+                  <Avatar>
+                    <AvatarImage alt="@shadcn" />
+                    <AvatarFallback className="bg-primary text-white">
+                      {contact.name.slice(0, 2).toUpperCase()}
+                    </AvatarFallback>
+                  </Avatar>
+                </TableCell>
+                <TableCell>{contact.email}</TableCell>
+                <TableCell>
+                  {formattedTotal === "$0.00" ? (
+                    <Badge variant={"destructive"}>Inactive</Badge>
+                  ) : (
+                    <Badge className="bg-emerald-700">Active</Badge>
+                  )}
+                </TableCell>
+                <TableCell>{format(contact.createdAt, "MM/dd/yyyy")}</TableCell>
+                <TableCell className="text-right">
+                  {formattedTotal}
+                </TableCell>
+              </TableRow>
+            );
+          })}
         </TableBody>
       </Table>
     </BlurPage>

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineLane.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineLane.tsx
@@ -34,6 +34,12 @@ import CustomModal from "@/components/global/CustomModal";
 import TicketForm from "@/components/forms/TicketForm";
 import PipelineTicket from "./PipelineTicket";
 
+// ⚡ Bolt: Cache Intl.NumberFormat outside component to prevent expensive re-instantiation on each render/loop iteration
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
 interface PipelaneLaneProps {
   setAllTickets: Dispatch<SetStateAction<TicketWithTags>>;
   allTickets: TicketWithTags;
@@ -55,11 +61,6 @@ const PipelineLane: React.FC<PipelaneLaneProps> = ({
 }) => {
   const { setOpen } = useModal();
   const router = useRouter();
-
-  const amt = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: "USD",
-  });
 
   const laneAmt = useMemo(() => {
     console.log(tickets);
@@ -159,7 +160,7 @@ const PipelineLane: React.FC<PipelaneLaneProps> = ({
                       </div>
                       <div className="flex items-center flex-row">
                         <Badge className="bg-white text-black">
-                          {amt.format(laneAmt)}
+                          {currencyFormatter.format(laneAmt)}
                         </Badge>
                         <DropdownMenuTrigger>
                           <MoreVertical className="text-muted-foreground cursor-pointer" />

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineTicket.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineTicket.tsx
@@ -43,6 +43,12 @@ import { useRouter } from "next/navigation";
 import React, { Dispatch, SetStateAction } from "react";
 import { Draggable } from "react-beautiful-dnd";
 
+// ⚡ Bolt: Cache Intl.NumberFormat outside component to prevent expensive re-instantiation on each render/loop iteration
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
 type Props = {
   setAllTickets: Dispatch<SetStateAction<TicketWithTags>>;
   ticket: TicketWithTags[0];
@@ -223,10 +229,7 @@ const PipelineTicket = ({
                     </div>
                     <span className="text-sm font-bold">
                       {!!ticket.value &&
-                        new Intl.NumberFormat(undefined, {
-                          style: "currency",
-                          currency: "USD",
-                        }).format(+ticket.value)}
+                        currencyFormatter.format(+ticket.value)}
                     </span>
                   </CardFooter>
                   <DropdownMenuContent>


### PR DESCRIPTION
💡 **What:** Hoisted the instantiation of `Intl.NumberFormat` out of React component render paths and `.map` iterations into module-level constants. Additionally, cached the formatted total value inside the `contacts/page.tsx` mapping loop to prevent calling it twice per table row.
🎯 **Why:** Creating `Intl.NumberFormat` objects is a known performance bottleneck in JS/V8, and doing it on every component render or loop iteration creates unnecessary CPU overhead. 
📊 **Impact:** Reduces redundant object allocations, CPU time, and eliminates the double-calculation of the `.reduce()` total loop in `contacts/page.tsx`.
🔬 **Measurement:** Verify with application build (`pnpm build`). No functionality loss while improving client and server render timings where these components are used.

---
*PR created automatically by Jules for task [8591772504978729988](https://jules.google.com/task/8591772504978729988) started by @lakshyarawat1*