### PR TITLE
⚡ Bolt: Cache Intl.NumberFormat instantiation for performance

### DIFF
--- a/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/contacts/page.tsx
@@ -3,6 +3,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import { db } from "@/lib/db";
+import { formatCurrency } from "@/lib/utils";
 import { SubAccount, Contact, Ticket } from "@prisma/client";
 import { format } from 'date-fns'
 import React from "react";
@@ -13,13 +14,6 @@ type Props = {
     subAccountId: string;
   };
 };
-
-// ⚡ Bolt Optimization: Instantiate Intl.NumberFormat outside the render loop.
-// Instantiating Intl objects is computationally expensive, especially inside a map loop where it's called twice per contact.
-const currencyFormatter = new Intl.NumberFormat(undefined, {
-  style: "currency",
-  currency: "USD",
-});
 
 const page = async ({ params }: Props) => {
   type SubAccountWithContacts = SubAccount & {
@@ -56,7 +50,7 @@ const page = async ({ params }: Props) => {
       0
     );
 
-    return currencyFormatter.format(laneAmt);
+    return formatCurrency(laneAmt);
   };
 
   return (

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineLane.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineLane.tsx
@@ -23,7 +23,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { deleteLane, saveActivityLogsNotification } from "@/lib/queries";
 import { LaneDetail, TicketWithTags } from "@/lib/types";
-import { cn } from "@/lib/utils";
+import { cn, formatCurrency } from "@/lib/utils";
 import { useModal } from "@/providers/model-provider";
 import { Draggable, Droppable } from "react-beautiful-dnd";
 import { Edit, MoreVertical, PlusCircleIcon, Trash } from "lucide-react";
@@ -55,11 +55,6 @@ const PipelineLane: React.FC<PipelaneLaneProps> = ({
 }) => {
   const { setOpen } = useModal();
   const router = useRouter();
-
-  const amt = new Intl.NumberFormat(undefined, {
-    style: "currency",
-    currency: "USD",
-  });
 
   const laneAmt = useMemo(() => {
     console.log(tickets);
@@ -159,7 +154,7 @@ const PipelineLane: React.FC<PipelaneLaneProps> = ({
                       </div>
                       <div className="flex items-center flex-row">
                         <Badge className="bg-white text-black">
-                          {amt.format(laneAmt)}
+                          {formatCurrency(laneAmt)}
                         </Badge>
                         <DropdownMenuTrigger>
                           <MoreVertical className="text-muted-foreground cursor-pointer" />

--- a/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineTicket.tsx
+++ b/web_app/src/app/(main)/subaccount/[subAccountId]/pipelines/_components/PipelineTicket.tsx
@@ -37,6 +37,7 @@ import {
 import { toast } from "@/components/ui/use-toast";
 import { deleteTicket, saveActivityLogsNotification } from "@/lib/queries";
 import { TicketWithTags } from "@/lib/types";
+import { formatCurrency } from "@/lib/utils";
 import { useModal } from "@/providers/model-provider";
 import { Contact2, Edit, MoreHorizontalIcon, Trash, User2 } from "lucide-react";
 import { useRouter } from "next/navigation";
@@ -222,11 +223,7 @@ const PipelineTicket = ({
                       </div>
                     </div>
                     <span className="text-sm font-bold">
-                      {!!ticket.value &&
-                        new Intl.NumberFormat(undefined, {
-                          style: "currency",
-                          currency: "USD",
-                        }).format(+ticket.value)}
+                      {!!ticket.value && formatCurrency(+ticket.value)}
                     </span>
                   </CardFooter>
                   <DropdownMenuContent>

--- a/web_app/src/lib/utils.ts
+++ b/web_app/src/lib/utils.ts
@@ -38,3 +38,11 @@ export function hexToString(hex : string) {
   // Remove any padding zeros if they were added
   return str.replace(/\0+$/, '');
 }
+const currencyFormatter = new Intl.NumberFormat(undefined, {
+  style: "currency",
+  currency: "USD",
+});
+
+export function formatCurrency(amount: number) {
+  return currencyFormatter.format(amount);
+}


### PR DESCRIPTION
💡 What: Created a centralized `formatCurrency` utility in `web_app/src/lib/utils.ts` to cache a single instance of `Intl.NumberFormat`, and refactored `PipelineLane.tsx`, `PipelineTicket.tsx`, and `contacts/page.tsx` to use it instead of repeatedly instantiating it inline.
🎯 Why: Instantiating `Intl` formatter objects is computationally expensive in V8. Doing so inside React render functions or loops forces re-instantiation per item or per render cycle, creating unnecessary CPU overhead and potential frame drops. 
📊 Impact: Reduces CPU overhead during render cycles by reusing a single formatter instance across the entire application, eliminating the O(N) penalty in list rendering (e.g. mapping tickets or contacts).
🔬 Measurement: Verified by running linter and building the Next.js app to ensure no functionality is broken.

---
*PR created automatically by Jules for task [12848648310803237291](https://jules.google.com/task/12848648310803237291) started by @lakshyarawat1*